### PR TITLE
Update config.rb to work on 3.1 and later

### DIFF
--- a/lib/nicinfo/config.rb
+++ b/lib/nicinfo/config.rb
@@ -187,7 +187,7 @@ module NicInfo
       retval = default
       if File.exist?( file_name )
         data_file = File.open( File.join( @app_data, name ), "r" )
-        retval = YAML::load( data_file )
+        retval = YAML::load( data_file, permitted_classes: [NicInfo::DataTree,NicInfo::Logger,NicInfo::DataNode,IO,Rainbow::Wrapper], aliases: true )
         data_file.close
       elsif default == nil
         raise "#{file_name} does not exist"


### PR DESCRIPTION
Under ruby 3.3, nicinfo fails if given an argument like "1=" with an error & stack trace citing line 190 in config.rb and missing classes/args to YAML::load. The apparent root cause is the adoption of[ "Psych.safe_load"](https://ruby-doc.org/stdlib-3.1.1/libdoc/psych/rdoc/Psych.html#method-c-safe_load) in Ruby v3.1.1

This patch adds permitted_classes and 'aliases:true' to get past those errors. e.g.:

```
 # nicinfo 1=
 # NicInfo v.1.5.2
 /opt/local/lib/ruby3.3/3.3.0/psych/class_loader.rb:99:in `find': Tried to load unspecified class: NicInfo::DataTree (Psych::DisallowedClass)
        from /opt/local/lib/ruby3.3/3.3.0/psych/class_loader.rb:28:in `load'
        from /opt/local/lib/ruby3.3/3.3.0/psych/visitors/to_ruby.rb:426:in `resolve_class'
        from /opt/local/lib/ruby3.3/3.3.0/psych/visitors/to_ruby.rb:215:in `visit_Psych_Nodes_Mapping'
        from /opt/local/lib/ruby3.3/3.3.0/psych/visitors/visitor.rb:30:in `visit'
        from /opt/local/lib/ruby3.3/3.3.0/psych/visitors/visitor.rb:6:in `accept'
        from /opt/local/lib/ruby3.3/3.3.0/psych/visitors/to_ruby.rb:35:in `accept'
        from /opt/local/lib/ruby3.3/3.3.0/psych/visitors/to_ruby.rb:320:in `visit_Psych_Nodes_Document'
        from /opt/local/lib/ruby3.3/3.3.0/psych/visitors/visitor.rb:30:in `visit'
        from /opt/local/lib/ruby3.3/3.3.0/psych/visitors/visitor.rb:6:in `accept'
        from /opt/local/lib/ruby3.3/3.3.0/psych/visitors/to_ruby.rb:35:in `accept'
        from /opt/local/lib/ruby3.3/3.3.0/psych.rb:334:in `safe_load'
        from /opt/local/lib/ruby3.3/3.3.0/psych.rb:369:in `load'
        from /opt/local/lib/ruby3.3/gems/3.3.0/gems/nicinfo-1.5.2/lib/nicinfo/config.rb:190:in `load_as_yaml'
        from /opt/local/lib/ruby3.3/gems/3.3.0/gems/nicinfo-1.5.2/lib/nicinfo/nicinfo_main.rb:491:in `run'
        from /opt/local/lib/ruby3.3/gems/3.3.0/gems/nicinfo-1.5.2/bin/nicinfo:25:in `<top (required)>'
        from /opt/local/bin/nicinfo:25:in `load'
        from /opt/local/bin/nicinfo:25:in `<main>'`
```
The single changed line is developed from the errors I got, not derived from examining the existing code. 